### PR TITLE
Specifiying node -v in the ci/cd pipeline

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          node-version: "23.10.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
There was a build error in the gut hub actions and it had to to do with the GitHub vm using an incorrect version of node. 