### PR TITLE
Fixed token cacheing issue with certain browsers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@fullcalendar/react": "^6.1.10",
         "@types/react-calendar": "^3.9.0",
         "@types/react-router-dom": "^5.3.3",
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-calendar": "^4.8.0",
         "react-dom": "^18.2.0",
@@ -2691,6 +2692,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@fullcalendar/react": "^6.1.10",
     "@types/react-calendar": "^3.9.0",
     "@types/react-router-dom": "^5.3.3",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-calendar": "^4.8.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/components/DashboardPage.tsx
+++ b/frontend/src/components/DashboardPage.tsx
@@ -4,6 +4,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import '../App.css';
 import { buildPath, API_ROUTES } from '../utils/api';
+import { checkAndClearToken } from '../utils/tokenUtils';
 
 interface Event {
   _id?: {
@@ -64,6 +65,12 @@ const DashboardPage: React.FC = () => {
   const [selectedDateStr, setSelectedDateStr] = useState<string>('');
 
   useEffect(() => {
+    // Check token expiration first
+    if (!checkAndClearToken()) {
+      window.location.href = '/login';
+      return;
+    }
+
     // Get user data from localStorage
     const userData = localStorage.getItem('user');
     if (userData) {

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,14 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import '../App.css';
 import { buildPath, API_ROUTES } from '../utils/api';
+import { checkAndClearToken } from '../utils/tokenUtils';
 
-const LoginPage = () => {
+const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const [emailOrUsername, setEmailOrUsername] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    // Check if user is already logged in with a valid token
+    if (checkAndClearToken()) {
+      navigate('/dashboard');
+    }
+  }, [navigate]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/utils/tokenUtils.ts
+++ b/frontend/src/utils/tokenUtils.ts
@@ -1,0 +1,25 @@
+import { jwtDecode } from 'jwt-decode';
+
+interface DecodedToken {
+  exp: number;
+  [key: string]: any;
+}
+
+export const isTokenExpired = (token: string): boolean => {
+  try {
+    const decodedToken = jwtDecode<DecodedToken>(token);
+    return Date.now() >= decodedToken.exp * 1000;
+  } catch (e) {
+    return true; // If token is malformed or invalid
+  }
+};
+
+export const checkAndClearToken = (): boolean => {
+  const token = localStorage.getItem('token');
+  if (!token || isTokenExpired(token)) {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    return false;
+  }
+  return true;
+}; 


### PR DESCRIPTION
Safari was aggressively cacheing the JWT token. Chrome sometimes would. This will check for invalid tokens, remove if found, and redirect to login.